### PR TITLE
Add `Signer` trait

### DIFF
--- a/src/keystore.rs
+++ b/src/keystore.rs
@@ -1,0 +1,13 @@
+use crate::{PublicKey, SecretKey};
+
+/// Keys container
+pub trait Keystore {
+    /// Identifier for the keypair
+    type KeyId;
+
+    /// Public key for a given id
+    fn public(&self, id: Self::KeyId) -> &PublicKey;
+
+    /// Secret key for a given id
+    fn secret(&self, id: Self::KeyId) -> &SecretKey;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,14 +8,22 @@
 
 mod error;
 mod hasher;
+mod keystore;
 mod message;
 mod public;
 mod secret;
 mod signature;
 
+#[cfg(feature = "std")]
+mod signer;
+
 pub use error::Error;
 pub use hasher::Hasher;
+pub use keystore::Keystore;
 pub use message::Message;
 pub use public::PublicKey;
 pub use secret::SecretKey;
 pub use signature::Signature;
+
+#[cfg(feature = "std")]
+pub use signer::Signer;

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -1,0 +1,29 @@
+use crate::{Error, Keystore, Message, Signature};
+
+/// Signature provider based on a keystore
+pub trait Signer {
+    /// Concrete keystore implementation
+    type Keystore: Keystore;
+
+    /// Accessor to the keystore
+    fn keystore(&self) -> &Self::Keystore;
+
+    /// Sign a given message with the secret key identified by `id`
+    fn sign(&self, id: <Self::Keystore as Keystore>::KeyId, message: &Message) -> Signature {
+        let secret = self.keystore().secret(id);
+
+        Signature::sign(secret, message)
+    }
+
+    /// Verify a given message with the public key identified by `id`
+    fn verify(
+        &self,
+        id: <Self::Keystore as Keystore>::KeyId,
+        signature: Signature,
+        message: &Message,
+    ) -> Result<(), Error> {
+        let public = self.keystore().public(id);
+
+        signature.verify(public, message)
+    }
+}


### PR DESCRIPTION
The signer trait precedes the concrete implementation of a
keystore+signer instance in fuel-crypto.

Related issue: #7