### PR TITLE
Bump fuel-types to v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "Fuel cryptographic primitives."
 
 [dependencies]
 borrown = "0.1"
-fuel-types = { version = "0.2", default-features = false }
+fuel-types = { version = "0.3", default-features = false }
 rand = { version = "0.8", default-features = false, features = ["std_rng"], optional = true }
 secp256k1 = { version = "0.20", features = ["recovery"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }


### PR DESCRIPTION
Even though this crate doesn't actually use anything in the new `fuel-types` version, it's needed in order to prevent crate version mismatch downstream.