### PR TITLE
Add `From<Hasher>` to signature `Message`

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -86,6 +86,20 @@ impl From<Message> for [u8; Message::LEN] {
     }
 }
 
+impl From<&Hasher> for Message {
+    fn from(hasher: &Hasher) -> Self {
+        // Safety: `Hasher` is a cryptographic hash
+        unsafe { Self::from_bytes_unchecked(*hasher.digest()) }
+    }
+}
+
+impl From<Hasher> for Message {
+    fn from(hasher: Hasher) -> Self {
+        // Safety: `Hasher` is a cryptographic hash
+        unsafe { Self::from_bytes_unchecked(*hasher.finalize()) }
+    }
+}
+
 impl fmt::LowerHex for Message {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)


### PR DESCRIPTION
Hasher is a cryptographic secure hasher and is allowed to produce
signature inputs.

Signatures are secure only if the input is pre-image checked and
non-malleable; this is a hard requirement for any signature protocol.