### PR TITLE
reexport dependencies used in the public api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default = ["fuel-types/default", "std"]
 random = ["fuel-types/random", "rand"]
 serde-types = ["fuel-types/serde-types", "secp256k1/serde", "serde-types-minimal", "serde/default", "std"]
 serde-types-minimal = ["fuel-types/serde-types-minimal", "serde"]
-std = ["fuel-types/default", "secp256k1"]
+std = ["fuel-types/std", "secp256k1"]
 
 [[test]]
 name = "test-signature"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,15 @@
 #![allow(clippy::wrong_self_convention)]
 
 /// Required export to implement [`Keystore`].
+#[doc(no_inline)]
 pub use borrown;
+/// Required export to use various public interfaces in this crate
+#[doc(no_inline)]
+pub use fuel_types;
+#[cfg(feature = "random")]
+#[doc(no_inline)]
+/// Required export to use randomness features
+pub use rand;
 
 mod error;
 mod hasher;


### PR DESCRIPTION
related: https://github.com/FuelLabs/fuel-core/issues/236

All external crates with types included in the public API of this library should be re-exported.