### PR TITLE
make docs feature aware on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,10 @@ required-features = ["std"]
 name = "test-signer"
 path = "tests/signer.rs"
 required-features = ["std"]
+
+# docs.rs-specific configuration
+[package.metadata.docs.rs]
+# document all features
+all-features = true
+# defines the configuration attribute `docsrs`
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Fuel cryptographic primitives.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs)]
 // Wrong clippy convention; check
 // https://rust-lang.github.io/api-guidelines/naming.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! Fuel cryptographic primitives.
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 // Wrong clippy convention; check
 // https://rust-lang.github.io/api-guidelines/naming.html


### PR DESCRIPTION
Leverage special nightly features enabled on docs.rs which allow denoting feature flags in our docs.
![fuel-crypto-docs](https://user-images.githubusercontent.com/794823/161182279-fb7c67e5-bbe0-4a2b-8cd6-bc7956d8dd47.png)



To test out the docs as docs.rs would render them use:
`RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --open`
