### PR TITLE
feat: expose more methods to WASM builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,13 @@ sha2 = "0.10"
 
 [features]
 default = ["fuel-types/default", "std"]
-alloc = ["rand/alloc", "secp256k1/alloc"]
+alloc = ["coins-bip32", "coins-bip39", "lazy_static/spin_no_std", "rand/alloc", "secp256k1/alloc"]
 random = ["fuel-types/random", "rand"]
 serde = ["dep:serde", "fuel-types/serde"]
 # `rand-std` is used to further protect the blinders from side-channel attacks and won't compromise
 # the deterministic arguments of the signature (key, nonce, message), as defined in the RFC-6979
-std = ["alloc", "coins-bip32", "coins-bip39", "fuel-types/std", "lazy_static", "rand/std_rng", "secp256k1/rand-std", "serde?/default"]
-wasm = ["secp256k1/rand"]
+std = ["alloc", "fuel-types/std", "lazy_static", "rand/std_rng", "secp256k1/rand-std", "serde?/default"]
+wasm = ["alloc", "secp256k1/rand"]
 
 [[test]]
 name = "test-mnemonic"

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,12 +44,11 @@ impl From<Infallible> for Error {
     }
 }
 
-#[cfg(feature = "std")]
-mod use_std {
+#[cfg(feature = "alloc")]
+mod use_alloc {
     use super::*;
     use coins_bip39::MnemonicError;
     use secp256k1::Error as Secp256k1Error;
-    use std::{error, fmt, io};
 
     impl From<Secp256k1Error> for Error {
         fn from(secp: Secp256k1Error) -> Self {
@@ -74,6 +73,12 @@ mod use_std {
             Self::InvalidMnemonic
         }
     }
+}
+
+#[cfg(feature = "std")]
+mod use_std {
+    use super::*;
+    use std::{error, fmt, io};
 
     impl From<coins_bip32::Bip32Error> for Error {
         fn from(_: coins_bip32::Bip32Error) -> Self {

--- a/src/message.rs
+++ b/src/message.rs
@@ -121,20 +121,14 @@ impl fmt::Display for Message {
     }
 }
 
-#[cfg(feature = "std")]
-mod use_std {
-    use crate::Message;
-
-    use secp256k1::Message as Secp256k1Message;
-
-    impl Message {
-        pub(crate) fn to_secp(&self) -> Secp256k1Message {
-            // The only validation performed by `Message::from_slice` is to check if it is
-            // 32 bytes. This validation exists to prevent users from signing
-            // non-hashed messages, which is a severe violation of the protocol
-            // security.
-            debug_assert_eq!(Self::LEN, secp256k1::constants::MESSAGE_SIZE);
-            Secp256k1Message::from_slice(self.as_ref()).expect("Unreachable error")
-        }
+#[cfg(feature = "alloc")]
+impl Message {
+    pub(crate) fn to_secp(&self) -> secp256k1::Message {
+        // The only validation performed by `Message::from_slice` is to check if it is
+        // 32 bytes. This validation exists to prevent users from signing
+        // non-hashed messages, which is a severe violation of the protocol
+        // security.
+        debug_assert_eq!(Self::LEN, secp256k1::constants::MESSAGE_SIZE);
+        secp256k1::Message::from_slice(self.as_ref()).expect("Unreachable error")
     }
 }

--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -1,25 +1,23 @@
 /// FuelMnemonic is a simple mnemonic phrase generator.
 pub struct FuelMnemonic;
 
-#[cfg(feature = "std")]
-mod use_std {
+#[cfg(all(feature = "alloc", feature = "random"))]
+mod use_alloc {
+    extern crate alloc;
     use super::FuelMnemonic;
-    use crate::Error;
+    use alloc::string::String;
     use coins_bip39::{English, Mnemonic};
+    use rand::Rng;
 
     pub type W = English;
-
-    #[cfg(feature = "random")]
-    use rand::Rng;
 
     impl FuelMnemonic {
         /// Generates a random mnemonic phrase given a random number generator and
         /// the number of words to generate, `count`.
-        #[cfg(feature = "random")]
         pub fn generate_mnemonic_phrase<R: Rng>(
             rng: &mut R,
             count: usize,
-        ) -> Result<String, Error> {
+        ) -> Result<String, crate::Error> {
             Ok(Mnemonic::<W>::new_with_count(rng, count)?.to_phrase()?)
         }
     }

--- a/src/public.rs
+++ b/src/public.rs
@@ -2,8 +2,7 @@ use crate::Hasher;
 
 use fuel_types::{Bytes32, Bytes64};
 
-use core::fmt;
-use core::ops::Deref;
+use core::{fmt, ops::Deref};
 
 /// Asymmetric public key
 #[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -62,66 +61,14 @@ impl PublicKey {
     }
 }
 
-impl Deref for PublicKey {
-    type Target = [u8; PublicKey::LEN];
-
-    fn deref(&self) -> &[u8; PublicKey::LEN] {
-        self.0.deref()
-    }
-}
-
-impl AsRef<[u8]> for PublicKey {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
-
-impl AsMut<[u8]> for PublicKey {
-    fn as_mut(&mut self) -> &mut [u8] {
-        self.0.as_mut()
-    }
-}
-
-impl From<PublicKey> for [u8; PublicKey::LEN] {
-    fn from(pk: PublicKey) -> [u8; PublicKey::LEN] {
-        pk.0.into()
-    }
-}
-
-impl fmt::LowerHex for PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl fmt::UpperHex for PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl fmt::Debug for PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl fmt::Display for PublicKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-#[cfg(feature = "std")]
-mod use_std {
+#[cfg(feature = "alloc")]
+mod use_alloc {
     use super::*;
     use crate::{Error, SecretKey};
 
     use secp256k1::{Error as Secp256k1Error, PublicKey as Secp256k1PublicKey, Secp256k1};
 
-    use core::borrow::Borrow;
-    use core::str;
-
+    use core::{borrow::Borrow, str};
     const UNCOMPRESSED_PUBLIC_KEY_SIZE: usize = 65;
 
     // Internal secp256k1 identifier for uncompressed point
@@ -193,19 +140,6 @@ mod use_std {
         }
     }
 
-    impl TryFrom<Bytes64> for PublicKey {
-        type Error = Error;
-
-        fn try_from(b: Bytes64) -> Result<Self, Self::Error> {
-            let public = PublicKey(b);
-
-            public
-                .is_in_curve()
-                .then(|| public)
-                .ok_or(Error::InvalidPublicKey)
-        }
-    }
-
     impl TryFrom<&[u8]> for PublicKey {
         type Error = Error;
 
@@ -238,5 +172,68 @@ mod use_std {
                 .map_err(|_| Secp256k1Error::InvalidPublicKey.into())
                 .and_then(PublicKey::try_from)
         }
+    }
+
+    impl TryFrom<Bytes64> for PublicKey {
+        type Error = Error;
+
+        fn try_from(b: Bytes64) -> Result<Self, Self::Error> {
+            let public = PublicKey(b);
+
+            public
+                .is_in_curve()
+                .then(|| public)
+                .ok_or(Error::InvalidPublicKey)
+        }
+    }
+}
+
+impl Deref for PublicKey {
+    type Target = [u8; PublicKey::LEN];
+
+    fn deref(&self) -> &[u8; PublicKey::LEN] {
+        self.0.deref()
+    }
+}
+
+impl AsRef<[u8]> for PublicKey {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl AsMut<[u8]> for PublicKey {
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.0.as_mut()
+    }
+}
+
+impl From<PublicKey> for [u8; PublicKey::LEN] {
+    fn from(pk: PublicKey) -> [u8; PublicKey::LEN] {
+        pk.0.into()
+    }
+}
+
+impl fmt::LowerHex for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::UpperHex for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
 }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -97,15 +97,28 @@ impl fmt::Display for SecretKey {
     }
 }
 
+#[cfg(feature = "alloc")]
+mod use_alloc {
+    use super::*;
+    use core::borrow::Borrow;
+    use secp256k1::SecretKey as Secp256k1SecretKey;
+    impl Borrow<Secp256k1SecretKey> for SecretKey {
+        fn borrow(&self) -> &Secp256k1SecretKey {
+            // Safety: field checked. The memory representation of the secp256k1 key is
+            // `[u8; 32]`
+            unsafe { &*(self.as_ref().as_ptr() as *const Secp256k1SecretKey) }
+        }
+    }
+}
+
 #[cfg(feature = "std")]
 mod use_std {
     use super::*;
     use crate::{Error, PublicKey};
     use coins_bip32::path::DerivationPath;
     use coins_bip39::{English, Mnemonic};
-    use core::borrow::Borrow;
     use core::str;
-    use secp256k1::{Error as Secp256k1Error, SecretKey as Secp256k1SecretKey};
+    use secp256k1::Error as Secp256k1Error;
     use std::str::FromStr;
 
     #[cfg(feature = "random")]
@@ -242,14 +255,6 @@ mod use_std {
             Bytes32::from_str(s)
                 .map_err(|_| Secp256k1Error::InvalidSecretKey.into())
                 .and_then(SecretKey::try_from)
-        }
-    }
-
-    impl Borrow<Secp256k1SecretKey> for SecretKey {
-        fn borrow(&self) -> &Secp256k1SecretKey {
-            // Safety: field checked. The memory representation of the secp256k1 key is
-            // `[u8; 32]`
-            unsafe { &*(self.as_ref().as_ptr() as *const Secp256k1SecretKey) }
         }
     }
 


### PR DESCRIPTION
This PR builds upon #26 and @vlopes11's comment to actually make WASM builds of `fuel-crypto` meaningfully usable. It requires reorganization of code in `#[cfg(feature = "std")]` blocks, as WASM is a no-std environment.

I imagine this PR to be unpleasant to review through diffs, so I'll list what methods were made available here when it's done™.