### PR TITLE
Re-export mnemonic deps

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,12 @@ pub use fuel_types;
 #[doc(no_inline)]
 /// Required export to use randomness features
 pub use rand;
+/// Required export for using mnemonic keygen on [`SecretKey::new_from_mnemonic`]
+#[cfg(feature = "std")]
 #[doc(no_inline)]
 pub use coins_bip39;
+/// Required export for using mnemonic keygen on [`SecretKey::new_from_mnemonic`]
+#[cfg(feature = "std")]
 #[doc(no_inline)]
 pub use coins_bip32;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,14 @@
 /// Required export to implement [`Keystore`].
 #[doc(no_inline)]
 pub use borrown;
+/// Required export for using mnemonic keygen on [`SecretKey::new_from_mnemonic`]
+#[cfg(feature = "std")]
+#[doc(no_inline)]
+pub use coins_bip32;
+/// Required export for using mnemonic keygen on [`SecretKey::new_from_mnemonic`]
+#[cfg(feature = "std")]
+#[doc(no_inline)]
+pub use coins_bip39;
 /// Required export to use various public interfaces in this crate
 #[doc(no_inline)]
 pub use fuel_types;
@@ -17,14 +25,6 @@ pub use fuel_types;
 #[doc(no_inline)]
 /// Required export to use randomness features
 pub use rand;
-/// Required export for using mnemonic keygen on [`SecretKey::new_from_mnemonic`]
-#[cfg(feature = "std")]
-#[doc(no_inline)]
-pub use coins_bip39;
-/// Required export for using mnemonic keygen on [`SecretKey::new_from_mnemonic`]
-#[cfg(feature = "std")]
-#[doc(no_inline)]
-pub use coins_bip32;
 
 mod error;
 mod hasher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,10 @@ pub use fuel_types;
 #[doc(no_inline)]
 /// Required export to use randomness features
 pub use rand;
+#[doc(no_inline)]
+pub use coins_bip39;
+#[doc(no_inline)]
+pub use coins_bip32;
 
 mod error;
 mod hasher;


### PR DESCRIPTION
We used types from third party libraries in our APIs which weren't re-exported. This means consumers of the library would have to include these same deps with matching versions in their own crates to use the secret key mnemonic api.